### PR TITLE
Fix for JTA helper class + other fixes

### DIFF
--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -381,7 +381,6 @@ private:
 
   // helper classes for associating PF candidates to jets
   IPProducerHelpers::FromJetAndCands m_helper;
-  IPProducerHelpers::FromJetAndCands m_helperFat;
 };
 
 template<typename IPTI,typename VTX>
@@ -413,8 +412,7 @@ BTagAnalyzerT<IPTI,VTX>::BTagAnalyzerT(const edm::ParameterSet& iConfig):
   hadronizerType_(0),
   pfjetIDLoose_( PFJetIDSelectionFunctor::FIRSTDATA, PFJetIDSelectionFunctor::LOOSE ),
   pfjetIDTight_( PFJetIDSelectionFunctor::FIRSTDATA, PFJetIDSelectionFunctor::TIGHT ),
-  m_helper(iConfig, consumesCollector(),"Jets"),
-  m_helperFat(iConfig, consumesCollector(),"FatJets")
+  m_helper(iConfig, consumesCollector(),"Jets")
 {
   //now do what ever initialization you need
   std::string module_type  = iConfig.getParameter<std::string>("@module_type");
@@ -3123,9 +3121,6 @@ template<>
 void BTagAnalyzerT<reco::CandIPTagInfo,reco::VertexCompositePtrCandidate>::fillHelpers(const edm::Event& iEvent)
 {
   std::vector<reco::JetTagInfo> jetTagInfos = m_helper.makeBaseVector(iEvent);
-  std::vector<reco::JetTagInfo> fatJetTagInfos;
-  if (runSubJets_)
-    fatJetTagInfos = m_helperFat.makeBaseVector(iEvent);
 }
 
 // -------------- toIPTagInfo ----------------
@@ -3173,7 +3168,7 @@ BTagAnalyzerT<reco::CandIPTagInfo,reco::VertexCompositePtrCandidate>::toAllTrack
   const reco::JetTagInfo * tagInfo = dynamic_cast<const reco::JetTagInfo *>( toIPTagInfo(jet,tagInfos) );
 
   if( iJetColl == 1)
-    return m_helperFat.tracks(*tagInfo);
+    return toIPTagInfo(jet,tagInfos)->selectedTracks();
   else
     return m_helper.tracks(*tagInfo);
 }

--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -3298,7 +3298,7 @@ void BTagAnalyzerT<reco::TrackIPTagInfo,reco::Vertex>::vertexKinematicsAndChange
 template<>
 void BTagAnalyzerT<reco::CandIPTagInfo,reco::VertexCompositePtrCandidate>::vertexKinematicsAndChange(const Vertex & vertex, reco::TrackKinematics & vertexKinematics, Int_t & charge)
 {
-  const std::vector<reco::CandidatePtr> tracks = vertex.daughterPtrVector();
+  const std::vector<reco::CandidatePtr> & tracks = vertex.daughterPtrVector();
 
   for(std::vector<reco::CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
     const reco::Track& mytrack = *(*track)->bestTrack();

--- a/test/runBTagAnalyzer_cfg.py
+++ b/test/runBTagAnalyzer_cfg.py
@@ -80,17 +80,15 @@ options.register('miniAOD', False,
     VarParsing.varType.bool,
     "Running on miniAOD"
 )
-
-options.register('useLegacyTaggers', True,
-VarParsing.multiplicity.singleton,
-VarParsing.varType.bool,
-"Use legacy taggers"
+options.register('useLegacyTaggers', False,
+    VarParsing.multiplicity.singleton,
+    VarParsing.varType.bool,
+    "Use legacy taggers"
 )
-
 options.register('useExplicitJTA', False,
-VarParsing.multiplicity.singleton,
-VarParsing.varType.bool,
-"Use explicit jet-track association"
+    VarParsing.multiplicity.singleton,
+    VarParsing.varType.bool,
+    "Use explicit jet-track association"
 )
 
 ## 'maxEvents' is already registered by the Framework, changing default value

--- a/test/runBTagAnalyzer_cfg.py
+++ b/test/runBTagAnalyzer_cfg.py
@@ -680,6 +680,7 @@ process.btagana.patMuonCollectionName = cms.InputTag(patMuons)
 process.btagana.use_ttbar_filter      = cms.bool(options.useTTbarFilter)
 process.btagana.triggerTable          = cms.InputTag('TriggerResults::HLT') # Data and MC
 process.btagana.genParticles          = cms.InputTag(genParticles)
+process.btagana.candidates            = cms.InputTag(pfCandidates) 
 
 if options.runSubJets:
     process.btaganaSubJets = process.btagana.clone(


### PR DESCRIPTION
- removed JTA helper for fat jets (it will no longer be possible to get all tracks associated to fat jets when running over fat jets and subjets in the new candidate-based framework. This is a bit of a loss in functionality but probably not critical)
- added `candidates` parameter in the main cfg file which also needs to be updated when running over MiniAOD
- making PF-based taggers a default option
