### PR TITLE
Switch to using already clustered jets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ git fetch --tags btv-cmssw
 git cms-merge-topic -u cms-btv-pog:FixHistoryBase-v1_from-CMSSW_8_0_12
 git cms-merge-topic -u cms-btv-pog:BoostedDoubleSVTaggerV3-WithWeightFiles-v1_from-CMSSW_8_0_8_patch1
 git cms-merge-topic -u cms-btv-pog:FixBoostedTauConfig_from-CMSSW_8_0_12
+git cms-merge-topic -u cms-btv-pog:SubjetTagInfosNoClustering-PR_from-CMSSW_8_0_12
 
-git clone -b 8_0_X_v1.06 --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
+git clone -b 8_0_X --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
 
 scram b -j8
 
 cd RecoBTag/PerformanceMeasurements/test/
 
-cmsRun runBTagAnalyzer_cfg.py miniAOD=False maxEvents=100 reportEvery=1 wantSummary=True
+cmsRun runBTagAnalyzer_cfg.py miniAOD=True maxEvents=100 reportEvery=1 wantSummary=True
 ```
 

--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -1808,7 +1808,7 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
       JetInfo[iJetColl].Jet_ptPruned[JetInfo[iJetColl].nJet]    = ( pjet->hasUserFloat("Pruned:Pt")         ? pjet->userFloat("Pruned:Pt")         : 0. );
       JetInfo[iJetColl].Jet_etaPruned[JetInfo[iJetColl].nJet]   = ( pjet->hasUserFloat("Pruned:Eta")        ? pjet->userFloat("Pruned:Eta")        : 0. );
       JetInfo[iJetColl].Jet_phiPruned[JetInfo[iJetColl].nJet]   = ( pjet->hasUserFloat("Pruned:Phi")        ? pjet->userFloat("Pruned:Phi")        : 0. );
-      JetInfo[iJetColl].Jet_massPruned[JetInfo[iJetColl].nJet]  = ( pjet->hasUserFloat("Pruned:Mass")       ? pjet->userFloat("Pruned:Mass")       : pjet->userFloat("ak8PFJetsCHSSoftDropMass") );
+      JetInfo[iJetColl].Jet_massPruned[JetInfo[iJetColl].nJet]  = ( pjet->hasUserFloat("Pruned:Mass")       ? pjet->userFloat("Pruned:Mass")       : pjet->userFloat("ak8PFJetsCHSPrunedMass") );
       JetInfo[iJetColl].Jet_jecF0Pruned[JetInfo[iJetColl].nJet] = ( pjet->hasUserFloat("Pruned:jecFactor0") ? pjet->userFloat("Pruned:jecFactor0") : 0. );
     }
     if ( runFatJets_ && runSubJets_ && iJetColl == 0 )

--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -1796,20 +1796,20 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
     if ( runFatJets_ && iJetColl == 0 )
     {
       // N-subjettiness
-      JetInfo[iJetColl].Jet_tau1[JetInfo[iJetColl].nJet] = pjet->userFloat("Njettiness:tau1");
-      JetInfo[iJetColl].Jet_tau2[JetInfo[iJetColl].nJet] = pjet->userFloat("Njettiness:tau2");
+      JetInfo[iJetColl].Jet_tau1[JetInfo[iJetColl].nJet] = ( pjet->hasUserFloat("Njettiness:tau1") ? pjet->userFloat("Njettiness:tau1") : pjet->userFloat("NjettinessAK8:tau1") );
+      JetInfo[iJetColl].Jet_tau2[JetInfo[iJetColl].nJet] = ( pjet->hasUserFloat("Njettiness:tau2") ? pjet->userFloat("Njettiness:tau2") : pjet->userFloat("NjettinessAK8:tau2") );
       // SoftDrop kinematics
-      JetInfo[iJetColl].Jet_ptSoftDrop[JetInfo[iJetColl].nJet]    = pjet->userFloat("SoftDrop:Pt");
-      JetInfo[iJetColl].Jet_etaSoftDrop[JetInfo[iJetColl].nJet]   = pjet->userFloat("SoftDrop:Eta");
-      JetInfo[iJetColl].Jet_phiSoftDrop[JetInfo[iJetColl].nJet]   = pjet->userFloat("SoftDrop:Phi");
-      JetInfo[iJetColl].Jet_massSoftDrop[JetInfo[iJetColl].nJet]  = pjet->userFloat("SoftDrop:Mass");
-      JetInfo[iJetColl].Jet_jecF0SoftDrop[JetInfo[iJetColl].nJet] = pjet->userFloat("SoftDrop:jecFactor0");
+      JetInfo[iJetColl].Jet_ptSoftDrop[JetInfo[iJetColl].nJet]    = ( pjet->hasUserFloat("SoftDrop:Pt")         ? pjet->userFloat("SoftDrop:Pt")         : 0. );
+      JetInfo[iJetColl].Jet_etaSoftDrop[JetInfo[iJetColl].nJet]   = ( pjet->hasUserFloat("SoftDrop:Eta")        ? pjet->userFloat("SoftDrop:Eta")        : 0. );
+      JetInfo[iJetColl].Jet_phiSoftDrop[JetInfo[iJetColl].nJet]   = ( pjet->hasUserFloat("SoftDrop:Phi")        ? pjet->userFloat("SoftDrop:Phi")        : 0. );
+      JetInfo[iJetColl].Jet_massSoftDrop[JetInfo[iJetColl].nJet]  = ( pjet->hasUserFloat("SoftDrop:Mass")       ? pjet->userFloat("SoftDrop:Mass")       : pjet->userFloat("ak8PFJetsCHSSoftDropMass") );
+      JetInfo[iJetColl].Jet_jecF0SoftDrop[JetInfo[iJetColl].nJet] = ( pjet->hasUserFloat("SoftDrop:jecFactor0") ? pjet->userFloat("SoftDrop:jecFactor0") : 0. );
       // Pruned kinematics
-      JetInfo[iJetColl].Jet_ptPruned[JetInfo[iJetColl].nJet]    = pjet->userFloat("Pruned:Pt");
-      JetInfo[iJetColl].Jet_etaPruned[JetInfo[iJetColl].nJet]   = pjet->userFloat("Pruned:Eta");
-      JetInfo[iJetColl].Jet_phiPruned[JetInfo[iJetColl].nJet]   = pjet->userFloat("Pruned:Phi");
-      JetInfo[iJetColl].Jet_massPruned[JetInfo[iJetColl].nJet]  = pjet->userFloat("Pruned:Mass");
-      JetInfo[iJetColl].Jet_jecF0Pruned[JetInfo[iJetColl].nJet] = pjet->userFloat("Pruned:jecFactor0");
+      JetInfo[iJetColl].Jet_ptPruned[JetInfo[iJetColl].nJet]    = ( pjet->hasUserFloat("Pruned:Pt")         ? pjet->userFloat("Pruned:Pt")         : 0. );
+      JetInfo[iJetColl].Jet_etaPruned[JetInfo[iJetColl].nJet]   = ( pjet->hasUserFloat("Pruned:Eta")        ? pjet->userFloat("Pruned:Eta")        : 0. );
+      JetInfo[iJetColl].Jet_phiPruned[JetInfo[iJetColl].nJet]   = ( pjet->hasUserFloat("Pruned:Phi")        ? pjet->userFloat("Pruned:Phi")        : 0. );
+      JetInfo[iJetColl].Jet_massPruned[JetInfo[iJetColl].nJet]  = ( pjet->hasUserFloat("Pruned:Mass")       ? pjet->userFloat("Pruned:Mass")       : pjet->userFloat("ak8PFJetsCHSSoftDropMass") );
+      JetInfo[iJetColl].Jet_jecF0Pruned[JetInfo[iJetColl].nJet] = ( pjet->hasUserFloat("Pruned:jecFactor0") ? pjet->userFloat("Pruned:jecFactor0") : 0. );
     }
     if ( runFatJets_ && runSubJets_ && iJetColl == 0 )
     {


### PR DESCRIPTION
At long last, this PR updates the BTagAnalyzer setup so that by default already clustered jets stored in AOD/MiniAOD are used. This change significantly speeds up the code.

Note that depending on the combination of options used and what is stored in AOD/MiniAOD in certain situation the BTagAnalyzer will fall back to jet reclustering. In case that happens, a message will be printed to the screen.

The simplest way to compare the performance before and after this latest addition is to run

```
cmsRun runBTagAnalyzer_cfg.py miniAOD=True maxEvents=200 reportEvery=1 wantSummary=True runJetClustering=True runFatJets=True runSubJets=True usePruned=False
```

for the old setup and

```
cmsRun runBTagAnalyzer_cfg.py miniAOD=True maxEvents=200 reportEvery=1 wantSummary=True runJetClustering=False runFatJets=True runSubJets=True usePruned=False
```

for the new one. In case you only want to process ak4 jets, remove the `runFatJets=True runSubJets=True usePruned=False` switches from the above commands.
