### PR TITLE
DeepFlavour PR

### DIFF
--- a/interface/JetInfoBranches.h
+++ b/interface/JetInfoBranches.h
@@ -45,6 +45,10 @@ class JetInfoBranches {
     float Jet_DeepFlavourUDS[nMaxJets_]		  ;
     float Jet_DeepFlavourG[nMaxJets_]       ;
 
+		float Jet_DeepFlavourBDiscN[nMaxJets_]   ;
+    float Jet_DeepFlavourCvsLDiscN[nMaxJets_];
+    float Jet_DeepFlavourCvsBDiscN[nMaxJets_];
+
     float Jet_DeepCSVBDisc[nMaxJets_]  ;
     float Jet_DeepCSVBDiscN[nMaxJets_]  ;
     float Jet_DeepCSVBDiscP[nMaxJets_]  ;
@@ -524,6 +528,9 @@ class JetInfoBranches {
 		  tree->Branch((name+"Jet_DeepFlavourUDS"     ).c_str(), Jet_DeepFlavourUDS	    , (name+"Jet_DeepFlavourUDS["+name+"nJet]/F"     ).c_str());
 		  tree->Branch((name+"Jet_DeepFlavourG"       ).c_str(), Jet_DeepFlavourG       , (name+"Jet_DeepFlavourG["+name+"nJet]/F"       ).c_str());
 
+		  tree->Branch((name+"Jet_DeepFlavourBDiscN"   ).c_str(), Jet_DeepFlavourBDiscN   , (name+"Jet_DeepFlavourBDiscN["+name+"nJet]/F"   ).c_str());
+		  tree->Branch((name+"Jet_DeepFlavourCvsLDiscN").c_str(), Jet_DeepFlavourCvsLDiscN, (name+"Jet_DeepFlavourCvsLDiscN["+name+"nJet]/F").c_str());
+		  tree->Branch((name+"Jet_DeepFlavourCvsBDiscN").c_str(), Jet_DeepFlavourCvsBDiscN, (name+"Jet_DeepFlavourCvsBDiscN["+name+"nJet]/F").c_str());
 
 		  tree->Branch((name+"Jet_DeepCSVBDisc"	 ).c_str(), Jet_DeepCSVBDisc	,(name+"Jet_DeepCSVBDisc["+name+"nJet]/F").c_str());
 		  tree->Branch((name+"Jet_DeepCSVBDiscN"	 ).c_str(), Jet_DeepCSVBDiscN, (name+"Jet_DeepCSVBDiscN["+name+"nJet]/F").c_str());

--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -308,6 +308,7 @@ private:
   std::string combinedSVPosBJetTags_;
 
 	std::string deepFlavourJetTags_;
+	std::string deepFlavourNegJetTags_;
 
 	std::string deepCSVBJetTags_;
 	std::string deepCSVNegBJetTags_;
@@ -648,6 +649,7 @@ BTagAnalyzerT<IPTI,VTX>::BTagAnalyzerT(const edm::ParameterSet& iConfig):
   combinedSVPosBJetTags_  = iConfig.getParameter<std::string>("combinedSVPosBJetTags");
 
 	deepFlavourJetTags_ = iConfig.getParameter<std::string>("deepFlavourJetTags");
+	deepFlavourNegJetTags_ = iConfig.getParameter<std::string>("deepFlavourNegJetTags");
 
 	deepCSVBJetTags_    = iConfig.getParameter<std::string>("deepCSVBJetTags");
 	deepCSVNegBJetTags_ = iConfig.getParameter<std::string>("deepCSVNegBJetTags");
@@ -741,7 +743,11 @@ BTagAnalyzerT<IPTI,VTX>::BTagAnalyzerT(const edm::ParameterSet& iConfig):
   if ( fillsvTagInfo_ )       JetInfo[0].RegisterJetSVTree(smalltree,branchNamePrefix_);
   if ( storeTagVariables_)    JetInfo[0].RegisterTagVarTree(smalltree,branchNamePrefix_);
   if ( storeCSVTagVariables_) JetInfo[0].RegisterCSVTagVarTree(smalltree,branchNamePrefix_);
-	if ( storeDeepFlavourTagVariables_) JetInfo[0].RegisterDeepFlavourFeatTree(smalltree,branchNamePrefix_);
+	std::cout << "storeDeepFlavourTagVariables_: " << storeDeepFlavourTagVariables_ << std::endl;
+	if ( storeDeepFlavourTagVariables_) {
+		std::cout << "storeDeepFlavourTagVariables_" << std::endl;
+		JetInfo[0].RegisterDeepFlavourFeatTree(smalltree,branchNamePrefix_);
+	}
   if ( storeCTagVariables_) JetInfo[0].RegisterCTagVarTree(smalltree,branchNamePrefix_);
   if ( runSubJets_ ) {
     for ( size_t i = 0; i < SubJetLabels_.size(); ++i )
@@ -2683,6 +2689,21 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
 			DeepFlavourG    = pjet->bDiscriminator((deepFlavourJetTags_+":probg").c_str());
 			}
 
+    float DeepFlavourBN    = -10.;
+		float DeepFlavourBBN   = -10.;
+		float DeepFlavourLepBN = -10.;
+    float DeepFlavourCN    = -10.;
+    float DeepFlavourUDSN  = -10.;
+    float DeepFlavourGN    = -10.;
+		if(deepFlavourJetTags_.size()) {
+			DeepFlavourBN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probb"   ).c_str());
+			DeepFlavourBBN   = pjet->bDiscriminator((deepFlavourNegJetTags_+":probbb"   ).c_str()); 
+			DeepFlavourLepBN = pjet->bDiscriminator((deepFlavourNegJetTags_+":problepb"   ).c_str());
+			DeepFlavourCN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probc"   ).c_str());
+			DeepFlavourUDSN  = pjet->bDiscriminator((deepFlavourNegJetTags_+":probuds").c_str());
+			DeepFlavourGN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probg").c_str());
+			}
+
     float DeepCSVb   = (deepCSVBJetTags_.size()) ? pjet->bDiscriminator((deepCSVBJetTags_+":probb"   ).c_str()) : -10;
     float DeepCSVc   = (deepCSVBJetTags_.size()) ? pjet->bDiscriminator((deepCSVBJetTags_+":probc"   ).c_str()) : -10;
     float DeepCSVl   = (deepCSVBJetTags_.size()) ? pjet->bDiscriminator((deepCSVBJetTags_+":probudsg").c_str()) : -10;
@@ -2728,16 +2749,23 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
     float CvsLPos = pjet->bDiscriminator(CvsLPosCJetTags_.c_str());
 
     // Jet information
+		//DeepFlavour discriminators
     JetInfo[iJetColl].Jet_DeepFlavourBDisc[JetInfo[iJetColl].nJet]     = DeepFlavourB + DeepFlavourBB + DeepFlavourLepB;
     JetInfo[iJetColl].Jet_DeepFlavourCvsLDisc[JetInfo[iJetColl].nJet]  = DeepFlavourC/(DeepFlavourC + DeepFlavourUDS + DeepFlavourG);
     JetInfo[iJetColl].Jet_DeepFlavourCvsBDisc[JetInfo[iJetColl].nJet]  = DeepFlavourC/(DeepFlavourC + DeepFlavourB + DeepFlavourBB + DeepFlavourLepB);
 
+		//DeepFlavour probabilities
     JetInfo[iJetColl].Jet_DeepFlavourB[JetInfo[iJetColl].nJet]    = DeepFlavourB   ;
     JetInfo[iJetColl].Jet_DeepFlavourBB[JetInfo[iJetColl].nJet]   = DeepFlavourBB  ;
     JetInfo[iJetColl].Jet_DeepFlavourLEPB[JetInfo[iJetColl].nJet] = DeepFlavourLepB;
     JetInfo[iJetColl].Jet_DeepFlavourC[JetInfo[iJetColl].nJet]    = DeepFlavourC   ;
     JetInfo[iJetColl].Jet_DeepFlavourUDS[JetInfo[iJetColl].nJet]  = DeepFlavourUDS ;
     JetInfo[iJetColl].Jet_DeepFlavourG[JetInfo[iJetColl].nJet]    = DeepFlavourG   ;
+
+		//DeepFlavour negative tags
+    JetInfo[iJetColl].Jet_DeepFlavourBDiscN[JetInfo[iJetColl].nJet]     = DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsLDiscN[JetInfo[iJetColl].nJet]  = DeepFlavourCN/(DeepFlavourCN + DeepFlavourUDSN + DeepFlavourGN);
+    JetInfo[iJetColl].Jet_DeepFlavourCvsBDiscN[JetInfo[iJetColl].nJet]  = DeepFlavourCN/(DeepFlavourCN + DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN);
 
     JetInfo[iJetColl].Jet_DeepCSVBDisc[JetInfo[iJetColl].nJet]   = DeepCSVb + DeepCSVbb  ;
     JetInfo[iJetColl].Jet_DeepCSVBDiscN[JetInfo[iJetColl].nJet]  = DeepCSVbN + DeepCSVbbN;

--- a/python/bTagAnalyzer_cfi.py
+++ b/python/bTagAnalyzer_cfi.py
@@ -21,6 +21,7 @@ bTagAnalyzer = cms.EDAnalyzer("BTagAnalyzer",
     softPFElectronTagInfosCTag = cms.string('softPFElectrons'),
     # taggers
 		deepFlavourJetTags = cms.string('pfDeepFlavourJetTags'),
+		deepFlavourNegJetTags = cms.string('pfNegativeDeepFlavourJetTags'),
 		deepCSVBJetTags    = cms.string('pfDeepCSVJetTags'),
 		deepCSVNegBJetTags = cms.string('pfNegativeDeepCSVJetTags'),
 	  deepCSVPosBJetTags = cms.string('pfPositiveDeepCSVJetTags'),

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -10,7 +10,7 @@ echo 'Running on MC'
 cmsRun runBTagAnalyzer_cfg.py defaults=Moriond18 runOnData=False maxEvents=20 &> last.log || die $?
 
 echo 'Rinning on AODSIM'
-cmsRun runBTagAnalyzer_cfg.py defaults=Moriond18 runOnData=False maxEvents=20 miniAOD=False inputFiles=/store/mc/RunIIFall17DRPremix/QCD_Pt_50to80_TuneCP5_13TeV_pythia8/AODSIM/94X_mc2017_realistic_v10-v1/60000/2AE14B27-6FE7-E711-B564-00266CF94C44.root useSelectedTracks=False fillsvTagInfo=True produceJetTrackTree=True doCTag=False || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=Moriond18 runOnData=False maxEvents=20 miniAOD=False inputFiles=/store/mc/RunIIFall17DRPremix/QCD_Pt_50to80_TuneCP5_13TeV_pythia8/AODSIM/94X_mc2017_realistic_v10-v1/60000/2AE14B27-6FE7-E711-B564-00266CF94C44.root useSelectedTracks=False fillsvTagInfo=True produceJetTrackTree=True doCTag=False &> last.log || die $?
 
 echo 'Running on data -- FatJets'
 cmsRun runBTagAnalyzer_cfg.py defaults=Moriond18 runOnData=True maxEvents=20 runFatJets=True &> last.log || die $?


### PR DESCRIPTION
This PR:
   * introduces back the DeepFlavour discriminators, with new training if paired with [this](https://github.com/cms-btv-pog/cmssw/pull/6) [1]
   * introduces the negative deep flavour tagger
   * **breaks the AOD and RECODEBUG workflows**. No clue why. The error message is:
```
----- Begin Fatal Exception 17-Apr-2018 11:58:14 CEST-----------------------
An exception of category 'ConfigurationError' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=ECFAdder label='ecfDbeta1'
Exception Message:
cuts and Njets must be the same size in ECFAdder
----- End Fatal Exception -------------------------------------------------
```
 I checked for the producer and is related to AK8Jets, but does not seem to be used anywhere in the code.
@ferencek @imarches can you have a look?

[1]
![stacked](https://user-images.githubusercontent.com/2329596/38864552-5eb6f952-423b-11e8-982e-f780aa5136b4.png)

[2]
![negative](https://user-images.githubusercontent.com/2329596/38864564-6803e2ea-423b-11e8-8212-08432fe3a101.png)

