### PR TITLE
add top-pt weights for ttbar mc

### DIFF
--- a/interface/EventInfoBranches.h
+++ b/interface/EventInfoBranches.h
@@ -174,7 +174,7 @@ class EventInfoBranches {
     float ttbar_lpt[10], ttbar_leta[10], ttbar_lphi[10], ttbar_lm[10];
     float ttbar_metpt,ttbar_metphi;
     float ttbar_w[1200];
-
+    float ttbar_ptweight;
 
     void RegisterTree(TTree *tree) {
       tree->Branch("nBitTrigger", &nBitTrigger,  "nBitTrigger/I");
@@ -344,6 +344,7 @@ class EventInfoBranches {
       tree->Branch("ttbar_metphi", &ttbar_metphi, "ttbar_metphi/F");
       tree->Branch("ttbar_nw"  ,  &ttbar_nw    , "ttbar_nw/I");
       tree->Branch("ttbar_w"    ,  ttbar_w     , "ttbar_w[ttbar_nw]/F");
+      tree->Branch("ttbar_ptweight", &ttbar_ptweight, "ttbar_ptweight/F");
     }
 
     //if storePatMuons
@@ -530,6 +531,7 @@ class EventInfoBranches {
       tree->SetBranchAddress("ttbar_metphi"  , &ttbar_metphi);
       tree->SetBranchAddress("ttbar_nw"  ,  &ttbar_nw);
       tree->SetBranchAddress("ttbar_w"    ,  ttbar_w);
+      tree->SetBranchAddress("ttbar_ptweight", &ttbar_ptweight);
     }
 
     //if storePatMuons

--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -1382,7 +1382,25 @@ void BTagAnalyzerT<IPTI,VTX>::analyze(const edm::Event& iEvent, const edm::Event
   // ttbar information
   //------------------------------------------------------
   if (use_ttbar_filter_) {
-
+    
+    //https://twiki.cern.ch/CMS/TopPtReweighting
+    EventInfo.ttbar_ptweight = 0.;
+    if (!isData_) {
+       float wtop = 0.;
+       float wantitop = 0.;
+       edm::Handle<reco::GenParticleCollection> prunedGenParticles;
+       iEvent.getByToken(prunedGenParticleCollectionName_, prunedGenParticles);
+       for (auto i = prunedGenParticles->begin(); i != prunedGenParticles->end(); ++i) {
+          if (i->pdgId()==6 && i->isLastCopy()) {
+             wtop = exp(0.0615-0.0005*i->pt());
+          }
+          if (i->pdgId()==-6 && i->isLastCopy()) {
+             wantitop = exp(0.0615-0.0005*i->pt());
+          }
+       }
+       EventInfo.ttbar_ptweight = sqrt(wtop*wantitop);
+    }
+      
     edm::Handle<int> pIn;
     iEvent.getByToken(ttbartop, pIn);
     EventInfo.ttbar_chan=*pIn;

--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -1388,9 +1388,9 @@ void BTagAnalyzerT<IPTI,VTX>::analyze(const edm::Event& iEvent, const edm::Event
     if (!isData_) {
        float wtop = 0.;
        float wantitop = 0.;
-       edm::Handle<reco::GenParticleCollection> prunedGenParticles;
-       iEvent.getByToken(prunedGenParticleCollectionName_, prunedGenParticles);
-       for (auto i = prunedGenParticles->begin(); i != prunedGenParticles->end(); ++i) {
+       edm::Handle<reco::GenParticleCollection> genParticles;
+       iEvent.getByToken(genParticleCollectionName_, genParticles);
+       for (auto i = genParticles->begin(); i != genParticles->end(); ++i) {
           if (i->pdgId()==6 && i->isLastCopy()) {
              wtop = exp(0.0615-0.0005*i->pt());
           }


### PR DESCRIPTION
Add the sf to correct for data / mc differences in the top pt spectrum in ttbar mc:
https://twiki.cern.ch/CMS/TopPtReweighting

Note that in order for these weights to be set correctly,
https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements/blob/9_4_X/python/bTagAnalyzerCommon_cff.py#L41
should be set to 'prunedGenParticles'. This modification is needed as the default 'prunedGenParticlesBoost' collection does not contain the isLastCopy particles. 