### PR TITLE
Set correct default values for combined tagger values

### DIFF
--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -2759,9 +2759,9 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
 
     // Jet information
     //DeepFlavour discriminators
-    JetInfo[iJetColl].Jet_DeepFlavourBDisc[JetInfo[iJetColl].nJet]     = (DeepFlavourB != -1000 && DeepFlavourBB != -1000 && DeepFlavourLepB != -1000) ? DeepFlavourB + DeepFlavourBB + DeepFlavourLepB : -1000;
-    JetInfo[iJetColl].Jet_DeepFlavourCvsLDisc[JetInfo[iJetColl].nJet]  = (DeepFlavourC != -1000 && DeepFlavourUDS != -1000 && DeepFlavourG != -1000) ? DeepFlavourC/(DeepFlavourC + DeepFlavourUDS + DeepFlavourG) : -1000;
-    JetInfo[iJetColl].Jet_DeepFlavourCvsBDisc[JetInfo[iJetColl].nJet]  = (DeepFlavourC != -1000 && DeepFlavourB != -1000 && DeepFlavourBB != -1000 && DeepFlavourLepB!= -1000) ? DeepFlavourC/(DeepFlavourC + DeepFlavourB + DeepFlavourBB + DeepFlavourLepB) : -1000;
+    JetInfo[iJetColl].Jet_DeepFlavourBDisc[JetInfo[iJetColl].nJet]     = (DeepFlavourB < -5) ? DeepFlavourB + DeepFlavourBB + DeepFlavourLepB : -10;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsLDisc[JetInfo[iJetColl].nJet]  = (DeepFlavourB < -5) ? DeepFlavourC/(DeepFlavourC + DeepFlavourUDS + DeepFlavourG) : -10;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsBDisc[JetInfo[iJetColl].nJet]  = (DeepFlavourB < -5) ? DeepFlavourC/(DeepFlavourC + DeepFlavourB + DeepFlavourBB + DeepFlavourLepB) : -10;
 
     //DeepFlavour probabilities
     JetInfo[iJetColl].Jet_DeepFlavourB[JetInfo[iJetColl].nJet]    = DeepFlavourB   ;
@@ -2772,9 +2772,9 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
     JetInfo[iJetColl].Jet_DeepFlavourG[JetInfo[iJetColl].nJet]    = DeepFlavourG   ;
 
     //DeepFlavour negative tags
-    JetInfo[iJetColl].Jet_DeepFlavourBDiscN[JetInfo[iJetColl].nJet]     = (DeepFlavourBN != -1000 && DeepFlavourBBN != -1000 && DeepFlavourLepBN != -1000) ? DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN : -1000;
-    JetInfo[iJetColl].Jet_DeepFlavourCvsLDiscN[JetInfo[iJetColl].nJet]  = (DeepFlavourCN != -1000 && DeepFlavourUDSN != -1000 && DeepFlavourGN != -1000) ? DeepFlavourCN/(DeepFlavourCN + DeepFlavourUDSN + DeepFlavourGN) : -1000;
-    JetInfo[iJetColl].Jet_DeepFlavourCvsBDiscN[JetInfo[iJetColl].nJet]  = (DeepFlavourCN != -1000 && DeepFlavourBN != -1000 && DeepFlavourBBN != -1000 && DeepFlavourLepBN != -1000) ? DeepFlavourCN/(DeepFlavourCN + DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN) : -1000;
+    JetInfo[iJetColl].Jet_DeepFlavourBDiscN[JetInfo[iJetColl].nJet]     = (DeepFlavourBN < -5) ? DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN : -10;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsLDiscN[JetInfo[iJetColl].nJet]  = (DeepFlavourBN < -5) ? DeepFlavourCN/(DeepFlavourCN + DeepFlavourUDSN + DeepFlavourGN) : -10;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsBDiscN[JetInfo[iJetColl].nJet]  = (DeepFlavourBN < -5) ? DeepFlavourCN/(DeepFlavourCN + DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN) : -10;
 
     JetInfo[iJetColl].Jet_DeepCSVBDisc[JetInfo[iJetColl].nJet]   = DeepCSVb + DeepCSVbb  ;
     JetInfo[iJetColl].Jet_DeepCSVBDiscN[JetInfo[iJetColl].nJet]  = DeepCSVbN + DeepCSVbbN;

--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -2683,34 +2683,35 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
     float CombinedSvtxP = pjet->bDiscriminator(combinedSVPosBJetTags_.c_str());
 
     float DeepFlavourB    = -10.;
-		float DeepFlavourBB   = -10.;
-		float DeepFlavourLepB = -10.;
+    float DeepFlavourBB   = -10.;
+    float DeepFlavourLepB = -10.;
     float DeepFlavourC    = -10.;
     float DeepFlavourUDS  = -10.;
     float DeepFlavourG    = -10.;
-		if(deepFlavourJetTags_.size()) {
-			DeepFlavourB    = pjet->bDiscriminator((deepFlavourJetTags_+":probb"   ).c_str());
-			DeepFlavourBB   = pjet->bDiscriminator((deepFlavourJetTags_+":probbb"   ).c_str()); 
-			DeepFlavourLepB = pjet->bDiscriminator((deepFlavourJetTags_+":problepb"   ).c_str());
-			DeepFlavourC    = pjet->bDiscriminator((deepFlavourJetTags_+":probc"   ).c_str());
-			DeepFlavourUDS  = pjet->bDiscriminator((deepFlavourJetTags_+":probuds").c_str());
-			DeepFlavourG    = pjet->bDiscriminator((deepFlavourJetTags_+":probg").c_str());
-			}
+    if(deepFlavourJetTags_.size()) {
+      DeepFlavourB    = pjet->bDiscriminator((deepFlavourJetTags_+":probb"   ).c_str());
+      DeepFlavourBB   = pjet->bDiscriminator((deepFlavourJetTags_+":probbb"   ).c_str());
+      DeepFlavourLepB = pjet->bDiscriminator((deepFlavourJetTags_+":problepb"   ).c_str());
+      DeepFlavourC    = pjet->bDiscriminator((deepFlavourJetTags_+":probc"   ).c_str());
+      DeepFlavourUDS  = pjet->bDiscriminator((deepFlavourJetTags_+":probuds").c_str());
+      DeepFlavourG    = pjet->bDiscriminator((deepFlavourJetTags_+":probg").c_str());
+    }
 
+    // Maybe set default value to -1000 in future, as this is the default returned by the bDiscriminator function if a tagger is not found there. (see http://cmslxr.fnal.gov/source/DataFormats/PatCandidates/src/Jet.cc#0377)
     float DeepFlavourBN    = -10.;
-		float DeepFlavourBBN   = -10.;
-		float DeepFlavourLepBN = -10.;
+    float DeepFlavourBBN   = -10.;
+    float DeepFlavourLepBN = -10.;
     float DeepFlavourCN    = -10.;
     float DeepFlavourUDSN  = -10.;
     float DeepFlavourGN    = -10.;
-		if(deepFlavourNegJetTags_.size()) {
-			DeepFlavourBN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probb"   ).c_str());
-			DeepFlavourBBN   = pjet->bDiscriminator((deepFlavourNegJetTags_+":probbb"   ).c_str()); 
-			DeepFlavourLepBN = pjet->bDiscriminator((deepFlavourNegJetTags_+":problepb"   ).c_str());
-			DeepFlavourCN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probc"   ).c_str());
-			DeepFlavourUDSN  = pjet->bDiscriminator((deepFlavourNegJetTags_+":probuds").c_str());
-			DeepFlavourGN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probg").c_str());
-			}
+    if(deepFlavourNegJetTags_.size()) {
+      DeepFlavourBN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probb"   ).c_str());
+      DeepFlavourBBN   = pjet->bDiscriminator((deepFlavourNegJetTags_+":probbb"   ).c_str());
+      DeepFlavourLepBN = pjet->bDiscriminator((deepFlavourNegJetTags_+":problepb"   ).c_str());
+      DeepFlavourCN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probc"   ).c_str());
+      DeepFlavourUDSN  = pjet->bDiscriminator((deepFlavourNegJetTags_+":probuds").c_str());
+      DeepFlavourGN    = pjet->bDiscriminator((deepFlavourNegJetTags_+":probg").c_str());
+    }
 
     float DeepCSVb   = (deepCSVBJetTags_.size()) ? pjet->bDiscriminator((deepCSVBJetTags_+":probb"   ).c_str()) : -10;
     float DeepCSVc   = (deepCSVBJetTags_.size()) ? pjet->bDiscriminator((deepCSVBJetTags_+":probc"   ).c_str()) : -10;
@@ -2757,12 +2758,12 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
     float CvsLPos = pjet->bDiscriminator(CvsLPosCJetTags_.c_str());
 
     // Jet information
-		//DeepFlavour discriminators
-    JetInfo[iJetColl].Jet_DeepFlavourBDisc[JetInfo[iJetColl].nJet]     = DeepFlavourB + DeepFlavourBB + DeepFlavourLepB;
-    JetInfo[iJetColl].Jet_DeepFlavourCvsLDisc[JetInfo[iJetColl].nJet]  = DeepFlavourC/(DeepFlavourC + DeepFlavourUDS + DeepFlavourG);
-    JetInfo[iJetColl].Jet_DeepFlavourCvsBDisc[JetInfo[iJetColl].nJet]  = DeepFlavourC/(DeepFlavourC + DeepFlavourB + DeepFlavourBB + DeepFlavourLepB);
+    //DeepFlavour discriminators
+    JetInfo[iJetColl].Jet_DeepFlavourBDisc[JetInfo[iJetColl].nJet]     = (DeepFlavourB != -1000 && DeepFlavourBB != -1000 && DeepFlavourLepB != -1000) ? DeepFlavourB + DeepFlavourBB + DeepFlavourLepB : -1000;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsLDisc[JetInfo[iJetColl].nJet]  = (DeepFlavourC != -1000 && DeepFlavourUDS != -1000 && DeepFlavourG != -1000) ? DeepFlavourC/(DeepFlavourC + DeepFlavourUDS + DeepFlavourG) : -1000;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsBDisc[JetInfo[iJetColl].nJet]  = (DeepFlavourC != -1000 && DeepFlavourB != -1000 && DeepFlavourBB != -1000 && DeepFlavourLepB!= -1000) ? DeepFlavourC/(DeepFlavourC + DeepFlavourB + DeepFlavourBB + DeepFlavourLepB) : -1000;
 
-		//DeepFlavour probabilities
+    //DeepFlavour probabilities
     JetInfo[iJetColl].Jet_DeepFlavourB[JetInfo[iJetColl].nJet]    = DeepFlavourB   ;
     JetInfo[iJetColl].Jet_DeepFlavourBB[JetInfo[iJetColl].nJet]   = DeepFlavourBB  ;
     JetInfo[iJetColl].Jet_DeepFlavourLEPB[JetInfo[iJetColl].nJet] = DeepFlavourLepB;
@@ -2770,10 +2771,10 @@ void BTagAnalyzerT<IPTI,VTX>::processJets(const edm::Handle<PatJetCollection>& j
     JetInfo[iJetColl].Jet_DeepFlavourUDS[JetInfo[iJetColl].nJet]  = DeepFlavourUDS ;
     JetInfo[iJetColl].Jet_DeepFlavourG[JetInfo[iJetColl].nJet]    = DeepFlavourG   ;
 
-		//DeepFlavour negative tags
-    JetInfo[iJetColl].Jet_DeepFlavourBDiscN[JetInfo[iJetColl].nJet]     = DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN;
-    JetInfo[iJetColl].Jet_DeepFlavourCvsLDiscN[JetInfo[iJetColl].nJet]  = DeepFlavourCN/(DeepFlavourCN + DeepFlavourUDSN + DeepFlavourGN);
-    JetInfo[iJetColl].Jet_DeepFlavourCvsBDiscN[JetInfo[iJetColl].nJet]  = DeepFlavourCN/(DeepFlavourCN + DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN);
+    //DeepFlavour negative tags
+    JetInfo[iJetColl].Jet_DeepFlavourBDiscN[JetInfo[iJetColl].nJet]     = (DeepFlavourBN != -1000 && DeepFlavourBBN != -1000 && DeepFlavourLepBN != -1000) ? DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN : -1000;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsLDiscN[JetInfo[iJetColl].nJet]  = (DeepFlavourCN != -1000 && DeepFlavourUDSN != -1000 && DeepFlavourGN != -1000) ? DeepFlavourCN/(DeepFlavourCN + DeepFlavourUDSN + DeepFlavourGN) : -1000;
+    JetInfo[iJetColl].Jet_DeepFlavourCvsBDiscN[JetInfo[iJetColl].nJet]  = (DeepFlavourCN != -1000 && DeepFlavourBN != -1000 && DeepFlavourBBN != -1000 && DeepFlavourLepBN != -1000) ? DeepFlavourCN/(DeepFlavourCN + DeepFlavourBN + DeepFlavourBBN + DeepFlavourLepBN) : -1000;
 
     JetInfo[iJetColl].Jet_DeepCSVBDisc[JetInfo[iJetColl].nJet]   = DeepCSVb + DeepCSVbb  ;
     JetInfo[iJetColl].Jet_DeepCSVBDiscN[JetInfo[iJetColl].nJet]  = DeepCSVbN + DeepCSVbbN;

--- a/plugins/EventCounter.cc
+++ b/plugins/EventCounter.cc
@@ -99,38 +99,6 @@ void
 EventCounter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
    hEventCount->Fill(0.);
-   if(!iEvent.isRealData()){
-      edm::Handle<GenEventInfoProduct> geninfos;
-      iEvent.getByToken( generator,geninfos );
-      int weightSign=1;
-      if(geninfos->weight()<0){
-         weightSign=-1;
-      }
-      
-      // pileup
-      edm::Handle<std::vector <PileupSummaryInfo> > PupInfo;
-      bool checkPUname = iEvent.getByToken(putoken, PupInfo);
-
-      if (checkPUname){
-          iEvent.getByToken(putoken, PupInfo);
-      } else{
-          iEvent.getByToken(putokenmini, PupInfo);
-      }
-      float nPUtrue=-1;
-      std::vector<PileupSummaryInfo>::const_iterator ipu;
-      for (ipu = PupInfo->begin(); ipu != PupInfo->end(); ++ipu) {
-          if ( ipu->getBunchCrossing() != 0 ) continue; //only for the active BX
-          nPUtrue = ipu->getTrueNumInteractions();      
-          break;
-      }
-
-
-      if(weightSign>0){
-          hPUPlusCount->Fill(nPUtrue);
-      } else {
-          hPUNegCount->Fill(nPUtrue);
-      }  
-   }
 }
 
 

--- a/plugins/EventCounter.cc
+++ b/plugins/EventCounter.cc
@@ -33,6 +33,9 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
 #include "TH1D.h"
 //
 // class declaration
@@ -58,8 +61,13 @@ class EventCounter : public edm::EDAnalyzer {
 
       // ----------member data ---------------------------
       edm::Service<TFileService> fs;
+      edm::EDGetTokenT<GenEventInfoProduct> generator;
+      edm::EDGetTokenT<std::vector<PileupSummaryInfo>> putoken;
+      edm::EDGetTokenT<std::vector<PileupSummaryInfo>> putokenmini;
 
       TH1D *hEventCount;
+      TH1D *hPUPlusCount;
+      TH1D *hPUNegCount;
 };
 
 //
@@ -74,10 +82,14 @@ class EventCounter : public edm::EDAnalyzer {
 // constructors and destructor
 //
 EventCounter::EventCounter(const edm::ParameterSet& iConfig)
-
 {
+   generator = consumes<GenEventInfoProduct>(edm::InputTag("generator"));
+   putoken = consumes<std::vector<PileupSummaryInfo>>(edm::InputTag("addPileupInfo"));
+   putokenmini = consumes<std::vector<PileupSummaryInfo>>(edm::InputTag("slimmedAddPileupInfo"));
    //now do what ever initialization is needed
-   hEventCount = fs->make<TH1D>("hEventCount","Even Count", 1, -0.5, 0.5);
+   hEventCount = fs->make<TH1D>("hEventCount","Event Count", 1, -0.5, 0.5);
+   hPUPlusCount = fs->make<TH1D>("hPUPlusCount","PU Plus Count", 100, 0, 100);
+   hPUNegCount  = fs->make<TH1D>("hPUNegCount", "PU Neg Count",  100, 0, 100);
 }
 
 
@@ -99,6 +111,40 @@ void
 EventCounter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
    hEventCount->Fill(0.);
+   if(!iEvent.isRealData()){
+      edm::Handle<GenEventInfoProduct> geninfos;
+      iEvent.getByToken( generator,geninfos );
+      int weightSign=1;
+      if(geninfos->weight()<0){
+         weightSign=-1;
+      }
+      
+      // pileup
+      edm::Handle<std::vector <PileupSummaryInfo> > PupInfo;
+      bool checkPUname = iEvent.getByToken(putoken, PupInfo);
+
+      if (checkPUname){
+          iEvent.getByToken(putoken, PupInfo);
+      } else{
+          iEvent.getByToken(putokenmini, PupInfo);
+      }
+      int nPU=-1;
+      float nPUtrue=-1;
+      std::vector<PileupSummaryInfo>::const_iterator ipu;
+      for (ipu = PupInfo->begin(); ipu != PupInfo->end(); ++ipu) {
+          if ( ipu->getBunchCrossing() != 0 ) continue; //only for the active BX
+	        nPU     = ipu->getPU_NumInteractions(); 
+          nPUtrue = ipu->getTrueNumInteractions();      
+          break;
+      }
+
+
+      if(weightSign>0){
+          hPUPlusCount->Fill(nPUtrue);
+      } else {
+          hPUNegCount->Fill(nPUtrue);
+      }  
+   }
 }
 
 

--- a/plugins/EventCounter.cc
+++ b/plugins/EventCounter.cc
@@ -128,12 +128,10 @@ EventCounter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       } else{
           iEvent.getByToken(putokenmini, PupInfo);
       }
-      int nPU=-1;
       float nPUtrue=-1;
       std::vector<PileupSummaryInfo>::const_iterator ipu;
       for (ipu = PupInfo->begin(); ipu != PupInfo->end(); ++ipu) {
           if ( ipu->getBunchCrossing() != 0 ) continue; //only for the active BX
-	        nPU     = ipu->getPU_NumInteractions(); 
           nPUtrue = ipu->getTrueNumInteractions();      
           break;
       }

--- a/plugins/EventCounter.cc
+++ b/plugins/EventCounter.cc
@@ -99,6 +99,38 @@ void
 EventCounter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
    hEventCount->Fill(0.);
+   if(!iEvent.isRealData()){
+      edm::Handle<GenEventInfoProduct> geninfos;
+      iEvent.getByToken( generator,geninfos );
+      int weightSign=1;
+      if(geninfos->weight()<0){
+         weightSign=-1;
+      }
+      
+      // pileup
+      edm::Handle<std::vector <PileupSummaryInfo> > PupInfo;
+      bool checkPUname = iEvent.getByToken(putoken, PupInfo);
+
+      if (checkPUname){
+          iEvent.getByToken(putoken, PupInfo);
+      } else{
+          iEvent.getByToken(putokenmini, PupInfo);
+      }
+      float nPUtrue=-1;
+      std::vector<PileupSummaryInfo>::const_iterator ipu;
+      for (ipu = PupInfo->begin(); ipu != PupInfo->end(); ++ipu) {
+          if ( ipu->getBunchCrossing() != 0 ) continue; //only for the active BX
+          nPUtrue = ipu->getTrueNumInteractions();      
+          break;
+      }
+
+
+      if(weightSign>0){
+          hPUPlusCount->Fill(nPUtrue);
+      } else {
+          hPUNegCount->Fill(nPUtrue);
+      }  
+   }
 }
 
 

--- a/python/defaults/Commissioning18.py
+++ b/python/defaults/Commissioning18.py
@@ -8,11 +8,11 @@ mc = {
         'inputFiles' : ['/store/relval/CMSSW_10_1_0_pre2/RelValTTbar_13/MINIAODSIM/100X_upgrade2018_realistic_v11-v1/20000/14AC524C-981E-E811-B6D1-0CC47A4D7632.root'],
         #'inputFiles' : ['/store/mc/RunIISpring18MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/100X_upgrade2018_realistic_v10-v1/30000/008B1124-0B31-E811-BD14-0025904C7A5A.root'], # Slightly older sample for testing
 	'JPCalibration' : 'JPcalib_MC94X_2017_v1',
-	'mcGlobalTag' : '94X_mc2017_realistic_v10',
+	'mcGlobalTag' : '94X_mc2017_realistic_v12',
 	}
 
 data = {
 	'inputFiles' : ['/store/data/Run2018A/JetHT/MINIAOD/PromptReco-v1/000/315/252/00000/04236AA8-404B-E811-9BD8-FA163EF52DAC.root'],
-	'JPCalibration' : 'JPcalib_Data94X_2017_v1',
+        'JPCalibration' : 'TrackProbabilityCalibration_PDF3D_express',
 	'dataGlobalTag' : '101X_dataRun2_Prompt_v9',
 }

--- a/python/defaults/Moriond18.py
+++ b/python/defaults/Moriond18.py
@@ -7,11 +7,11 @@ common = {
 mc = {
 	'inputFiles' : ['/store/mc/RunIIFall17MiniAOD/TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/60000/002E7FEA-16E0-E711-922D-0242AC130002.root'],
 	'JPCalibration' : 'JPcalib_MC94X_2017_v1',
-	'mcGlobalTag' : '94X_mc2017_realistic_v10',
+        'mcGlobalTag' : '94X_mc2017_realistic_v12',
 	}
 
 data = {
 	'inputFiles' : ['/store/data/Run2017D/JetHT/MINIAOD/17Nov2017-v1/20000/0249B143-8CCC-E711-BA7C-0025905C2CD0.root'],	
-	'JPCalibration' : 'JPcalib_Data94X_2017_v1',
+	'JPCalibration' : 'TrackProbabilityCalibration_PDF3D_v1_offline',
 	'dataGlobalTag' : '94X_dataRun2_ReReco_EOY17_v2',
 }

--- a/test/runBTagAnalyzer_cfg.py
+++ b/test/runBTagAnalyzer_cfg.py
@@ -50,15 +50,15 @@ options.register('usePuppiForBTagging', False,
     VarParsing.varType.bool,
     "Use Puppi candidates for b tagging"
 )
-options.register('mcGlobalTag', '92X_upgrade2017_realistic_v1',
+options.register('mcGlobalTag', 'FIXME',
     VarParsing.multiplicity.singleton,
     VarParsing.varType.string,
-    "MC global tag"
+    "MC global tag, no default value provided"
 )
-options.register('dataGlobalTag', '92X_dataRun2_Prompt_v7', 
+options.register('dataGlobalTag', 'FIXME',
     VarParsing.multiplicity.singleton,
     VarParsing.varType.string,
-    "Data global tag"
+    "Data global tag, no default value provided"
 )
 options.register('runJetClustering', False,
     VarParsing.multiplicity.singleton,
@@ -229,18 +229,18 @@ options.register('minJetPt', 20.0,
     VarParsing.varType.float,
     "Minimum jet pt (default is 20)"
 )
-options.register('usePrivateJEC', True,
+options.register('usePrivateJEC', False,
     VarParsing.multiplicity.singleton,
     VarParsing.varType.bool,
     'Use JECs from private SQLite files')
-options.register('jecDBFileMC', 'Fall17_17Nov2017_V4_MC', 
+options.register('jecDBFileMC', 'FIXME',
     VarParsing.multiplicity.singleton,
     VarParsing.varType.string,
-    'SQLite filename for JECs')
-options.register('jecDBFileData', 'Fall17_17Nov2017B_V4_DATA',
+    'SQLite filename for JECs, no default value provided')
+options.register('jecDBFileData', 'FIXME',
     VarParsing.multiplicity.singleton,
     VarParsing.varType.string,
-    'SQLite filename for JECs')
+    'SQLite filename for JECs, no default value provided')
 options.register('isReHLT', False,
     VarParsing.multiplicity.singleton,
     VarParsing.varType.bool,
@@ -800,12 +800,7 @@ if options.usePrivateJEC:
     process.es_prefer_jec = cms.ESPrefer("PoolDBESSource",'jec')
 
 ### to activate the new JP calibration: using the data base
-trkProbaCalibTag = "JPcalib_MC81X_v0"
-if options.runOnData:
-  trkProbaCalibTag = "JPcalib_Data80X_2016_v3"
-if options.JPCalibration:
-	trkProbaCalibTag = options.JPCalibration
-# process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
+trkProbaCalibTag = options.JPCalibration
 process.GlobalTag.toGet = cms.VPSet(
     cms.PSet(record = cms.string("BTagTrackProbability3DRcd"),
       tag = cms.string(trkProbaCalibTag),


### PR DESCRIPTION
Default value is now -1000 if the tagger is not found (this is also the default value returned by the bDiscriminator function for the single values)