### PR TITLE
Updating branch for Phase2 in 11_1_X

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,16 @@
 ## Software setup
 
 ```
-cmsrel CMSSW_11_0_0_patch1 
-cd CMSSW_11_0_0_patch1/src
+cmsrel CMSSW_11_1_2 
+cd CMSSW_11_1_2/src
 cmsenv
 
 setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
 git cms-init
 
 git cms-addpkg RecoBTag
-git cms-merge-topic emilbols:BTV_11_0_X
 
-git clone -b Phase2_11_0_X_v1.02 --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
+git clone -b Phase2_11_1_X --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
 
 scram b -j8
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ scram b -j8
 The ntuplizer can be run and configured through ```RecoBTag/PerformanceMeasurements/test/runBTagAnalyzer_cfg.py```
 
 ```
-cmsRun runBTagAnalyzer_cfg.py runOnData=(True or False, depending on your needs)
+cmsRun runBTagAnalyzer_cfg.py defaults=PhaseII runOnData=(True or False, depending on your needs)
 ```
 
 To run the tests for integrating changes run:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
 git cms-init
 
 git cms-addpkg RecoBTag
+git cms-merge-topic emilbols:BTV_CMSSW_11_1_X
 
 git clone -b Phase2_11_1_X --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
 

--- a/plugins/BTagAnalyzer.cc
+++ b/plugins/BTagAnalyzer.cc
@@ -827,7 +827,7 @@ void BTagAnalyzerT<IPTI,VTX>::analyze(const edm::Event& iEvent, const edm::Event
     std::string moduleName = "";
     const edm::Provenance& prov = iEvent.getProvenance(genEvtInfoProduct.id());
     if( genEvtInfoProduct.isValid() )
-      moduleName = edm::moduleName(prov);
+      moduleName = edm::moduleName(prov,iEvent.processHistory());
 
     if( moduleName.find("Pythia8")!=std::string::npos )
       hadronizerType_ |= ( 1 << 1 ); // set the 2nd bit

--- a/test/runBTagAnalyzer_cfg.py
+++ b/test/runBTagAnalyzer_cfg.py
@@ -335,6 +335,7 @@ options.setDefault('maxEvents', -1)
 #$$
 
 options.parseArguments()
+
 if options.defaults:
 	from importlib import import_module
 	try:


### PR DESCRIPTION
Created a new branch in CMSSW11_1_2 for Phase2 studies. Using the merge topic **emilbols:BTV_CMSSW_11_1_X** from https://github.com/emilbols/RecoBTag-PerformanceMeasurements.git prepared by @emilbols 

The analyzer runs ok with the phase2 option with a few warnings.