### PR TITLE
BTA recipe for UltraLegacy2018 data and MC with preliminary JECs (V5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ NOTE1: due to the structure of the preliminary JECs, there are 5 different "defa
 
 > **_MC_**: ```defaults=2018_UltraLegacy```<br/>
 > **_Run2018A_**: ```defaults=2018_UltraLegacy_DataRunA```<br/>
-> **_Run2018B_**: ```defaults=2017_UltraLegacy_DataRunB```<br/>
-> **_Run2018C_**: ```defaults=2017_UltraLegacy_DataRunC```<br/>
-> **_Run2018D_**: ```defaults=2017_UltraLegacy_DataRunD```
+> **_Run2018B_**: ```defaults=2018_UltraLegacy_DataRunB```<br/>
+> **_Run2018C_**: ```defaults=2018_UltraLegacy_DataRunC```<br/>
+> **_Run2018D_**: ```defaults=2018_UltraLegacy_DataRunD```
 
 This means in your crab configuration file, you will have to check which file you are running on, and pick the correct default set accordingly. As an example, one might do something like:
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Software setup
 
 ```
-cmsrel CMSSW_10_6_8_patch1 
-cd CMSSW_10_6_8_patch1/src
+cmsrel CMSSW_10_6_12 
+cd CMSSW_10_6_12/src
 cmsenv
 
 for bash
@@ -15,7 +15,7 @@ setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
 
 git cms-init
 
-git clone -b 10_6_X_UL2018_PreliminaryJECs --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
+git clone -b 10_6_X_v2.01 --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
 
 scram b -j8
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ cmsrel CMSSW_10_6_8_patch1
 cd CMSSW_10_6_8_patch1/src
 cmsenv
 
+for bash
+export CMSSW_GIT_REFERENCE=/cvmfs/cms.cern.ch/cmssw.git.daily
+
+for tcsh
 setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
+
 git cms-init
 
 git clone -b 10_6_X_UL2018_PreliminaryJECs --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cmsenv
 setenv CMSSW_GIT_REFERENCE /cvmfs/cms.cern.ch/cmssw.git.daily
 git cms-init
 
-git clone -b 10_6_X_v1.05 --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
+git clone -b 10_6_X_UL2018_PreliminaryJECs --depth 1 https://github.com/cms-btv-pog/RecoBTag-PerformanceMeasurements.git RecoBTag/PerformanceMeasurements
 
 scram b -j8
 
@@ -18,32 +18,29 @@ scram b -j8
 
 The ntuplizer can be run and configured through ```RecoBTag/PerformanceMeasurements/test/runBTagAnalyzer_cfg.py```.
 
-NOTE1: due to the structure of the preliminary JECs, there are 6 different "defaults" sets; 
+NOTE1: due to the structure of the preliminary JECs, there are 5 different "defaults" sets; 
 
-> **_MC_**: ```defaults=2017_UltraLegacy```<br/>
-> **_Run2017B_**: ```defaults=2017_UltraLegacy_DataRunB```<br/>
-> **_Run2017C_**: ```defaults=2017_UltraLegacy_DataRunC```<br/>
-> **_Run2017D_**: ```defaults=2017_UltraLegacy_DataRunD```<br/>
-> **_Run2017E_**: ```defaults=2017_UltraLegacy_DataRunE```<br/>
-> **_Run2017F_**: ```defaults=2017_UltraLegacy_DataRunF```
+> **_MC_**: ```defaults=2018_UltraLegacy```<br/>
+> **_Run2018A_**: ```defaults=2018_UltraLegacy_DataRunA```<br/>
+> **_Run2018B_**: ```defaults=2017_UltraLegacy_DataRunB```<br/>
+> **_Run2018C_**: ```defaults=2017_UltraLegacy_DataRunC```<br/>
+> **_Run2018D_**: ```defaults=2017_UltraLegacy_DataRunD```
 
 This means in your crab configuration file, you will have to check which file you are running on, and pick the correct default set accordingly. As an example, one might do something like:
 
 ```
 ...
-config.Data.inputDataset = /BTagMu/Run2017D-09Aug2019_UL2017-v1/MINIAOD
-if "Run2017B" in config.Data.inputDataset: 
-	config.JobType.pyCfgParams = [defaults=2017_UltraLegacy_DataRunB ,...]
-elif "Run2017C" in config.Data.inputDataset: 
-	config.JobType.pyCfgParams = [defaults=2017_UltraLegacy_DataRunC ,...]
-elif "Run2017D" in config.Data.inputDataset: 
-	config.JobType.pyCfgParams = [defaults=2017_UltraLegacy_DataRunD ,...]
-elif "Run2017E" in config.Data.inputDataset: 
-	config.JobType.pyCfgParams = [defaults=2017_UltraLegacy_DataRunE ,...]
-elif "Run2017F" in config.Data.inputDataset: 
-	config.JobType.pyCfgParams = [defaults=2017_UltraLegacy_DataRunF ,...]
+config.Data.inputDataset = /BTagMu/Run2018A-12Nov2019_UL2018-v1/MINIAOD
+if "Run2018A" in config.Data.inputDataset: 
+	config.JobType.pyCfgParams = [defaults=2018_UltraLegacy_DataRunA ,...]
+elif "Run2018B" in config.Data.inputDataset: 
+	config.JobType.pyCfgParams = [defaults=2018_UltraLegacy_DataRunB ,...]
+elif "Run2018C" in config.Data.inputDataset: 
+	config.JobType.pyCfgParams = [defaults=2018_UltraLegacy_DataRunC ,...]
+elif "Run2018D" in config.Data.inputDataset: 
+	config.JobType.pyCfgParams = [defaults=2018_UltraLegacy_DataRunD ,...]
 else: 
-	config.JobType.pyCfgParams = [defaults=2017_UltraLegacy ,...]
+	config.JobType.pyCfgParams = [defaults=2018_UltraLegacy ,...]
 ...
 ```
 

--- a/python/defaults/2018_UltraLegacy.py
+++ b/python/defaults/2018_UltraLegacy.py
@@ -7,13 +7,13 @@ common = {
 mc = {
 	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
 	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
-	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'mcGlobalTag' : '106X_upgrade2018_realistic_v11_L1v1',
 	'jecDBFileMC': 'Summer19UL18_V5_MC',
 	}
 
 data = {
 	'inputFiles' : ['/store/data/Run2018B/BTagMu/MINIAOD/12Nov2019_UL2018-v1/00000/02220C7E-2468-C04F-9796-207FABF509C2.root'],	
     'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
-	'dataGlobalTag' : '106X_dataRun2_v24',
+	'dataGlobalTag' : '106X_dataRun2_v28',
 	'jecDBFileData': 'Summer19UL18_RunB_V5_DATA',
 }

--- a/python/defaults/2018_UltraLegacy.py
+++ b/python/defaults/2018_UltraLegacy.py
@@ -1,0 +1,19 @@
+common = {
+	'eras' : ['Run2_2018'],
+	'miniAOD' : True,
+	'usePrivateJEC': True,
+}
+
+mc = {
+	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
+	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
+	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'jecDBFileMC': 'Summer19UL18_V5_MC',
+	}
+
+data = {
+	'inputFiles' : ['/store/data/Run2018B/BTagMu/MINIAOD/12Nov2019_UL2018-v1/00000/02220C7E-2468-C04F-9796-207FABF509C2.root'],	
+    'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
+	'dataGlobalTag' : '106X_dataRun2_v24',
+	'jecDBFileData': 'Summer19UL18_RunB_V5_DATA',
+}

--- a/python/defaults/2018_UltraLegacy_DataRunA.py
+++ b/python/defaults/2018_UltraLegacy_DataRunA.py
@@ -7,13 +7,13 @@ common = {
 mc = {
 	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
 	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
-	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'mcGlobalTag' : '106X_upgrade2018_realistic_v11_L1v1',
 	'jecDBFileMC': 'Summer19UL18_V5_MC',
 	}
 
 data = {
 	'inputFiles' : ['/store/data/Run2018A/BTagMu/MINIAOD/12Nov2019_UL2018-v1/00000/035456C6-D99D-FD4B-AFA8-DF0B544C65C9.root'],	
     'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
-	'dataGlobalTag' : '106X_dataRun2_v24',
+	'dataGlobalTag' : '106X_dataRun2_v28',
 	'jecDBFileData': 'Summer19UL18_RunA_V5_DATA',
 }

--- a/python/defaults/2018_UltraLegacy_DataRunA.py
+++ b/python/defaults/2018_UltraLegacy_DataRunA.py
@@ -1,0 +1,19 @@
+common = {
+	'eras' : ['Run2_2018'],
+	'miniAOD' : True,
+	'usePrivateJEC': True,
+}
+
+mc = {
+	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
+	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
+	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'jecDBFileMC': 'Summer19UL18_V5_MC',
+	}
+
+data = {
+	'inputFiles' : ['/store/data/Run2018A/BTagMu/MINIAOD/12Nov2019_UL2018-v1/00000/035456C6-D99D-FD4B-AFA8-DF0B544C65C9.root'],	
+    'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
+	'dataGlobalTag' : '106X_dataRun2_v24',
+	'jecDBFileData': 'Summer19UL18_RunA_V5_DATA',
+}

--- a/python/defaults/2018_UltraLegacy_DataRunB.py
+++ b/python/defaults/2018_UltraLegacy_DataRunB.py
@@ -7,13 +7,13 @@ common = {
 mc = {
 	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
 	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
-	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'mcGlobalTag' : '106X_upgrade2018_realistic_v11_L1v1',
 	'jecDBFileMC': 'Summer19UL18_V5_MC',
 	}
 
 data = {
 	'inputFiles' : ['/store/data/Run2018B/BTagMu/MINIAOD/12Nov2019_UL2018-v1/00000/02220C7E-2468-C04F-9796-207FABF509C2.root'],	
     'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
-	'dataGlobalTag' : '106X_dataRun2_v24',
+	'dataGlobalTag' : '106X_dataRun2_v28',
 	'jecDBFileData': 'Summer19UL18_RunB_V5_DATA',
 }

--- a/python/defaults/2018_UltraLegacy_DataRunB.py
+++ b/python/defaults/2018_UltraLegacy_DataRunB.py
@@ -1,0 +1,19 @@
+common = {
+	'eras' : ['Run2_2018'],
+	'miniAOD' : True,
+	'usePrivateJEC': True,
+}
+
+mc = {
+	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
+	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
+	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'jecDBFileMC': 'Summer19UL18_V5_MC',
+	}
+
+data = {
+	'inputFiles' : ['/store/data/Run2018B/BTagMu/MINIAOD/12Nov2019_UL2018-v1/00000/02220C7E-2468-C04F-9796-207FABF509C2.root'],	
+    'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
+	'dataGlobalTag' : '106X_dataRun2_v24',
+	'jecDBFileData': 'Summer19UL18_RunB_V5_DATA',
+}

--- a/python/defaults/2018_UltraLegacy_DataRunC.py
+++ b/python/defaults/2018_UltraLegacy_DataRunC.py
@@ -1,0 +1,19 @@
+common = {
+	'eras' : ['Run2_2018'],
+	'miniAOD' : True,
+	'usePrivateJEC': True,
+}
+
+mc = {
+	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
+	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
+	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'jecDBFileMC': 'Summer19UL18_V5_MC',
+	}
+
+data = {
+	'inputFiles' : ['/store/data/Run2018C/BTagMu/MINIAOD/12Nov2019_UL2018-v1/110000/0CABAFB6-0250-324B-AF4B-BCCE7DD62007.root'],
+    'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
+	'dataGlobalTag' : '106X_dataRun2_v24',
+	'jecDBFileData': 'Summer19UL18_RunC_V5_DATA',
+}

--- a/python/defaults/2018_UltraLegacy_DataRunC.py
+++ b/python/defaults/2018_UltraLegacy_DataRunC.py
@@ -7,13 +7,13 @@ common = {
 mc = {
 	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
 	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
-	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'mcGlobalTag' : '106X_upgrade2018_realistic_v11_L1v1',
 	'jecDBFileMC': 'Summer19UL18_V5_MC',
 	}
 
 data = {
 	'inputFiles' : ['/store/data/Run2018C/BTagMu/MINIAOD/12Nov2019_UL2018-v1/110000/0CABAFB6-0250-324B-AF4B-BCCE7DD62007.root'],
     'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
-	'dataGlobalTag' : '106X_dataRun2_v24',
+	'dataGlobalTag' : '106X_dataRun2_v28',
 	'jecDBFileData': 'Summer19UL18_RunC_V5_DATA',
 }

--- a/python/defaults/2018_UltraLegacy_DataRunD.py
+++ b/python/defaults/2018_UltraLegacy_DataRunD.py
@@ -1,0 +1,19 @@
+common = {
+	'eras' : ['Run2_2018'],
+	'miniAOD' : True,
+	'usePrivateJEC': True,
+}
+
+mc = {
+	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
+	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
+	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'jecDBFileMC': 'Summer19UL18_V5_MC',
+	}
+
+data = {
+	'inputFiles' : ['/store/data/Run2018D/BTagMu/MINIAOD/12Nov2019_UL2018-v1/00000/02214801-C65E-4D4E-A041-F61B93E7BB47.root'],	
+    'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
+	'dataGlobalTag' : '106X_dataRun2_v24',
+	'jecDBFileData': 'Summer19UL18_RunD_V5_DATA',
+}

--- a/python/defaults/2018_UltraLegacy_DataRunD.py
+++ b/python/defaults/2018_UltraLegacy_DataRunD.py
@@ -7,13 +7,13 @@ common = {
 mc = {
 	'inputFiles' : ['/store/mc/RunIISummer19UL18MiniAOD/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/260000/00C28834-56C0-2343-B436-AA8521756E9E.root'],
 	'JPCalibration' : 'JPcalib_MC106X_UL2018_v1',
-	'mcGlobalTag' : '106X_mc2018_realistic_v11_L1v1',
+	'mcGlobalTag' : '106X_upgrade2018_realistic_v11_L1v1',
 	'jecDBFileMC': 'Summer19UL18_V5_MC',
 	}
 
 data = {
 	'inputFiles' : ['/store/data/Run2018D/BTagMu/MINIAOD/12Nov2019_UL2018-v1/00000/02214801-C65E-4D4E-A041-F61B93E7BB47.root'],	
     'JPCalibration' : 'JPcalib_Data106X_UL2018_v1',
-	'dataGlobalTag' : '106X_dataRun2_v24',
+	'dataGlobalTag' : '106X_dataRun2_v28',
 	'jecDBFileData': 'Summer19UL18_RunD_V5_DATA',
 }

--- a/test/runBTagAnalyzer_cfg.py
+++ b/test/runBTagAnalyzer_cfg.py
@@ -50,12 +50,12 @@ options.register('usePuppiForBTagging', False,
     VarParsing.varType.bool,
     "Use Puppi candidates for b tagging"
 )
-options.register('mcGlobalTag', 'FIXME',
+options.register('mcGlobalTag', '106X_mc2018_realistic_v11_L1v1',
     VarParsing.multiplicity.singleton,
     VarParsing.varType.string,
     "MC global tag, no default value provided"
 )
-options.register('dataGlobalTag', 'FIXME',
+options.register('dataGlobalTag', '106X_dataRun2_v24',
     VarParsing.multiplicity.singleton,
     VarParsing.varType.string,
     "Data global tag, no default value provided"
@@ -886,7 +886,7 @@ process.GlobalTag.globaltag = globalTag
 #process.es_prefer_BTauMVAJetTagComputerRecord = cms.ESPrefer("PoolDBESSource","BTauMVAJetTagComputerRecord")
 
 if options.usePrivateJEC and options.runFatJets:
-	print "\n No private UL2017 JECs available yet for FatJets! Using whatever is in the GT."
+	print "\n No private UL2018 JECs available yet for FatJets! Using whatever is in the GT."
 
 if options.usePrivateJEC and not options.runFatJets:
 

--- a/test/runBTagAnalyzer_cfg.py
+++ b/test/runBTagAnalyzer_cfg.py
@@ -55,7 +55,7 @@ options.register('mcGlobalTag', '106X_mc2018_realistic_v11_L1v1',
     VarParsing.varType.string,
     "MC global tag, no default value provided"
 )
-options.register('dataGlobalTag', '106X_dataRun2_v24',
+options.register('dataGlobalTag', '106X_dataRun2_v28',
     VarParsing.multiplicity.singleton,
     VarParsing.varType.string,
     "Data global tag, no default value provided"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -4,31 +4,31 @@ set -o errexit
 function die { echo 'FAILED': status $1 ; }
 
 echo 'Running on data'
-cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy runOnData=True maxEvents=20 groups='test' &> last.log || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=2018_UltraLegacy runOnData=True maxEvents=20 groups='test' &> last.log || die $?
 
 echo 'Running on MC'
-cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy runOnData=False maxEvents=20 groups='test' &> last.log || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=2018_UltraLegacy runOnData=False maxEvents=20 groups='test' &> last.log || die $?
 
 # echo 'Rinning on AODSIM'
 # cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy runOnData=False maxEvents=20 miniAOD=False inputFiles=/store/mc/RunIIAutumn18DRPremix/QCD_Pt_80to120_TuneCP5_13TeV_pythia8/AODSIM/102X_upgrade2018_realistic_v15-v1/1010000/FA97679F-774B-7F43-9258-D8A0AE3A7A01.root useSelectedTracks=False produceJetTrackTree=True runCTagVariables=False groups='test' &> last.log || die $?
 
 echo 'Running on data -- FatJets'
-cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy runOnData=True maxEvents=20 runFatJets=True groups='testfat' &> last.log || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=2018_UltraLegacy runOnData=True maxEvents=20 runFatJets=True groups='testfat' &> last.log || die $?
 
 echo 'Running on MC -- FatJets'
-cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy runOnData=False maxEvents=20 runFatJets=True groups='testfat' &> last.log || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=2018_UltraLegacy runOnData=False maxEvents=20 runFatJets=True groups='testfat' &> last.log || die $?
 
 echo 'Running on data -- commissioning'
-cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy useSelectedTracks=False produceJetTrackTree=True runOnData=True maxEvents=20  groups='test'&> last.log || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=2018_UltraLegacy useSelectedTracks=False produceJetTrackTree=True runOnData=True maxEvents=20  groups='test'&> last.log || die $?
 
 echo 'Running on MC -- commissioning'
-cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy useSelectedTracks=False produceJetTrackTree=True runOnData=False maxEvents=20 groups='test' &> last.log || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=2018_UltraLegacy useSelectedTracks=False produceJetTrackTree=True runOnData=False maxEvents=20 groups='test' &> last.log || die $?
 
 echo 'Running on data -- ctag'
-cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy runOnData=True maxEvents=20 runCTagVariables=True runFatJets=True runSubJets=True groups='testfat' &> last.log || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=2018_UltraLegacy runOnData=True maxEvents=20 runCTagVariables=True runFatJets=True runSubJets=True groups='testfat' &> last.log || die $?
 
 echo 'Running on MC -- ctag'
-cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy runOnData=False maxEvents=20 runCTagVariables=True runFatJets=True runSubJets=True groups='testfat' &> last.log || die $?
+cmsRun runBTagAnalyzer_cfg.py defaults=2018_UltraLegacy runOnData=False maxEvents=20 runCTagVariables=True runFatJets=True runSubJets=True groups='testfat' &> last.log || die $?
 
 # echo 'RECODEBUG'
 # cmsRun runBTagAnalyzer_cfg.py defaults=2017_UltraLegacy runOnData=False maxEvents=20 miniAOD=False runFatJets=True runSubJets=True useTrackHistory=True produceJetTrackTree=True inputFiles=/store/mc/RunIIFall17DRPremix/QCD_Pt_15to30_TuneCP5_13TeV_pythia8/GEN-SIM-RECODEBUG/94X_mc2017_realistic_v10-v1/70000/04F991F0-C2DD-E711-B302-0CC47A78A3F8.root groups='testfat' &> last.log || die $?


### PR DESCRIPTION
 Complete BTA recipe for UltraLegacy2018 data and MC processing with latest (V5) JECs from https://twiki.cern.ch/twiki/bin/viewauth/CMS/JECDataMC 